### PR TITLE
Add rbnacl-libsodium instead of rbnacl alone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'pry'
 gem 'rake'
 
 # Security
-gem 'rbnacl'
+gem 'rbnacl-libsodium'
 
 # Database
 gem 'hirb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       ffi (>= 0.5.0, < 2)
     rbnacl (5.0.0)
       ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     rerun (0.13.0)
       listen (~> 3.0)
     roda (3.6.0)
@@ -65,7 +67,7 @@ DEPENDENCIES
   puma
   rack-test
   rake
-  rbnacl
+  rbnacl-libsodium
   rerun
   roda
   rubocop

--- a/lib/secure_db.rb
+++ b/lib/secure_db.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'base64'
-require 'rbnacl'
+require 'rbnacl/libsodium'
 
 # Encrypt and Decrypt from Database
 class SecureDB


### PR DESCRIPTION
Hey folks, I'm sending PR with my suggestion to use rbnacl/libsodium so that others don't have to install libsodium separately:

`Gemfile`: change to `gem 'rbnacl-libsodium'`
`Gemfile.lock`: after bundle install it includes `rbnacl-libsodium`
`lib/secure_db.rb`: change to `require 'rbnacl/libsodium'`